### PR TITLE
Add GeoParquet example notebook

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -43,7 +43,7 @@ website:
         - section: Kerchunk
           contents:
           - kerchunk/intro.qmd
-          - kerchunk/kerchunk-in-practice.ipynb          
+          - kerchunk/kerchunk-in-practice.ipynb
         - section: Cloud-Optimized HDF5 and NetCDF
           contents:
             - cloud-optimized-netcdf4-hdf5/index.qmd
@@ -53,12 +53,13 @@ website:
         - section: GeoParquet
           contents:
             - geoparquet/index.qmd
+            - geoparquet/geoparquet-example.ipynb
         - section: FlatGeobuf
           contents:
             - flatgeobuf/intro.qmd
             - flatgeobuf/hilbert-r-tree.qmd
       - href: cookbooks/index.qmd
-        text: Cookbooks        
+        text: Cookbooks
       - href: contributing.qmd
         text: Get Involved
 

--- a/geoparquet/geoparquet-example.ipynb
+++ b/geoparquet/geoparquet-example.ipynb
@@ -18,6 +18,45 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Package versions\n",
+    "\n",
+    "This notebook requires the dependency [`pyarrow`](https://pypi.org/project/pyarrow/) as well as the GDAL CLI with the Parquet driver installed.\n",
+    "\n",
+    "To install `pyarrow` you can use pip:\n",
+    "\n",
+    "```bash\n",
+    "!pip install pyarrow\n",
+    "```\n",
+    "\n",
+    "To install the GDAL CLI with Parquet driver you can use Mamba\n",
+    "\n",
+    "```bash\n",
+    "!mamba install -c conda-forge libgdal-arrow-parquet\n",
+    "```\n",
+    "\n",
+    "or if you're on MacOS, you can use `brew` to install GDAL including Parquet support:\n",
+    "\n",
+    "```bash\n",
+    "brew install gdal\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Imports"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": []
+  },
+  {
    "cell_type": "code",
    "execution_count": 4,
    "metadata": {},
@@ -82,7 +121,7 @@
     }
    ],
    "source": [
-    "%timeit gdf = gpd.read_parquet(\"countries.parquet\")"
+    "%time gdf = gpd.read_parquet(\"countries.parquet\")"
    ]
   },
   {
@@ -108,7 +147,7 @@
     }
    ],
    "source": [
-    "%timeit gdf.to_parquet(\"countries_written.parquet\")"
+    "%time gdf.to_parquet(\"countries_written.parquet\")"
    ]
   },
   {

--- a/geoparquet/geoparquet-example.ipynb
+++ b/geoparquet/geoparquet-example.ipynb
@@ -33,11 +33,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Reading from local disk\n",
+    "## Comparison with FlatGeobuf\n",
     "\n",
-    "First we'll cover reading and writing GeoParquet files on local disk storage.\n",
-    "\n",
-    "To be consistent with the FlatGeobuf example, we'll fetch the same US counties FlatGeobuf file (13 MB) and convert it to GeoParquet using `ogr2ogr`."
+    "In order to compare reading GeoParquet with FlatGeobuf, we'll cover reading and writing GeoParquet files on local disk storage. To be consistent with the FlatGeobuf example, we'll fetch the same US counties FlatGeobuf file (13 MB) and convert it to GeoParquet using `ogr2ogr`."
    ]
   },
   {
@@ -182,21 +180,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [
     {
-     "ename": "KeyboardInterrupt",
-     "evalue": "",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mKeyboardInterrupt\u001b[0m                         Traceback (most recent call last)",
-      "File \u001b[0;32m<timed exec>:1\u001b[0m\n",
-      "File \u001b[0;32m~/.pyenv/versions/3.11.4/lib/python3.11/site-packages/geopandas/io/arrow.py:598\u001b[0m, in \u001b[0;36m_read_parquet\u001b[0;34m(path, columns, storage_options, **kwargs)\u001b[0m\n\u001b[1;32m    596\u001b[0m path \u001b[39m=\u001b[39m _expand_user(path)\n\u001b[1;32m    597\u001b[0m kwargs[\u001b[39m\"\u001b[39m\u001b[39muse_pandas_metadata\u001b[39m\u001b[39m\"\u001b[39m] \u001b[39m=\u001b[39m \u001b[39mTrue\u001b[39;00m\n\u001b[0;32m--> 598\u001b[0m table \u001b[39m=\u001b[39m parquet\u001b[39m.\u001b[39;49mread_table(path, columns\u001b[39m=\u001b[39;49mcolumns, filesystem\u001b[39m=\u001b[39;49mfilesystem, \u001b[39m*\u001b[39;49m\u001b[39m*\u001b[39;49mkwargs)\n\u001b[1;32m    600\u001b[0m \u001b[39m# read metadata separately to get the raw Parquet FileMetaData metadata\u001b[39;00m\n\u001b[1;32m    601\u001b[0m \u001b[39m# (pyarrow doesn't properly exposes those in schema.metadata for files\u001b[39;00m\n\u001b[1;32m    602\u001b[0m \u001b[39m# created by GDAL - https://issues.apache.org/jira/browse/ARROW-16688)\u001b[39;00m\n\u001b[1;32m    603\u001b[0m metadata \u001b[39m=\u001b[39m \u001b[39mNone\u001b[39;00m\n",
-      "File \u001b[0;32m~/.pyenv/versions/3.11.4/lib/python3.11/site-packages/pyarrow/parquet/core.py:2986\u001b[0m, in \u001b[0;36mread_table\u001b[0;34m(source, columns, use_threads, metadata, schema, use_pandas_metadata, read_dictionary, memory_map, buffer_size, partitioning, filesystem, filters, use_legacy_dataset, ignore_prefixes, pre_buffer, coerce_int96_timestamp_unit, decryption_properties, thrift_string_size_limit, thrift_container_size_limit)\u001b[0m\n\u001b[1;32m   2975\u001b[0m         \u001b[39m# TODO test that source is not a directory or a list\u001b[39;00m\n\u001b[1;32m   2976\u001b[0m         dataset \u001b[39m=\u001b[39m ParquetFile(\n\u001b[1;32m   2977\u001b[0m             source, metadata\u001b[39m=\u001b[39mmetadata, read_dictionary\u001b[39m=\u001b[39mread_dictionary,\n\u001b[1;32m   2978\u001b[0m             memory_map\u001b[39m=\u001b[39mmemory_map, buffer_size\u001b[39m=\u001b[39mbuffer_size,\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m   2983\u001b[0m             thrift_container_size_limit\u001b[39m=\u001b[39mthrift_container_size_limit,\n\u001b[1;32m   2984\u001b[0m         )\n\u001b[0;32m-> 2986\u001b[0m     \u001b[39mreturn\u001b[39;00m dataset\u001b[39m.\u001b[39;49mread(columns\u001b[39m=\u001b[39;49mcolumns, use_threads\u001b[39m=\u001b[39;49muse_threads,\n\u001b[1;32m   2987\u001b[0m                         use_pandas_metadata\u001b[39m=\u001b[39;49muse_pandas_metadata)\n\u001b[1;32m   2989\u001b[0m warnings\u001b[39m.\u001b[39mwarn(\n\u001b[1;32m   2990\u001b[0m     \u001b[39m\"\u001b[39m\u001b[39mPassing \u001b[39m\u001b[39m'\u001b[39m\u001b[39muse_legacy_dataset=True\u001b[39m\u001b[39m'\u001b[39m\u001b[39m to get the legacy behaviour is \u001b[39m\u001b[39m\"\u001b[39m\n\u001b[1;32m   2991\u001b[0m     \u001b[39m\"\u001b[39m\u001b[39mdeprecated as of pyarrow 8.0.0, and the legacy implementation will \u001b[39m\u001b[39m\"\u001b[39m\n\u001b[1;32m   2992\u001b[0m     \u001b[39m\"\u001b[39m\u001b[39mbe removed in a future version.\u001b[39m\u001b[39m\"\u001b[39m,\n\u001b[1;32m   2993\u001b[0m     \u001b[39mFutureWarning\u001b[39;00m, stacklevel\u001b[39m=\u001b[39m\u001b[39m2\u001b[39m)\n\u001b[1;32m   2995\u001b[0m \u001b[39mif\u001b[39;00m ignore_prefixes \u001b[39mis\u001b[39;00m \u001b[39mnot\u001b[39;00m \u001b[39mNone\u001b[39;00m:\n",
-      "File \u001b[0;32m~/.pyenv/versions/3.11.4/lib/python3.11/site-packages/pyarrow/parquet/core.py:2614\u001b[0m, in \u001b[0;36m_ParquetDatasetV2.read\u001b[0;34m(self, columns, use_threads, use_pandas_metadata)\u001b[0m\n\u001b[1;32m   2606\u001b[0m         index_columns \u001b[39m=\u001b[39m [\n\u001b[1;32m   2607\u001b[0m             col \u001b[39mfor\u001b[39;00m col \u001b[39min\u001b[39;00m _get_pandas_index_columns(metadata)\n\u001b[1;32m   2608\u001b[0m             \u001b[39mif\u001b[39;00m \u001b[39mnot\u001b[39;00m \u001b[39misinstance\u001b[39m(col, \u001b[39mdict\u001b[39m)\n\u001b[1;32m   2609\u001b[0m         ]\n\u001b[1;32m   2610\u001b[0m         columns \u001b[39m=\u001b[39m (\n\u001b[1;32m   2611\u001b[0m             \u001b[39mlist\u001b[39m(columns) \u001b[39m+\u001b[39m \u001b[39mlist\u001b[39m(\u001b[39mset\u001b[39m(index_columns) \u001b[39m-\u001b[39m \u001b[39mset\u001b[39m(columns))\n\u001b[1;32m   2612\u001b[0m         )\n\u001b[0;32m-> 2614\u001b[0m table \u001b[39m=\u001b[39m \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49m_dataset\u001b[39m.\u001b[39;49mto_table(\n\u001b[1;32m   2615\u001b[0m     columns\u001b[39m=\u001b[39;49mcolumns, \u001b[39mfilter\u001b[39;49m\u001b[39m=\u001b[39;49m\u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49m_filter_expression,\n\u001b[1;32m   2616\u001b[0m     use_threads\u001b[39m=\u001b[39;49muse_threads\n\u001b[1;32m   2617\u001b[0m )\n\u001b[1;32m   2619\u001b[0m \u001b[39m# if use_pandas_metadata, restore the pandas metadata (which gets\u001b[39;00m\n\u001b[1;32m   2620\u001b[0m \u001b[39m# lost if doing a specific `columns` selection in to_table)\u001b[39;00m\n\u001b[1;32m   2621\u001b[0m \u001b[39mif\u001b[39;00m use_pandas_metadata:\n",
-      "\u001b[0;31mKeyboardInterrupt\u001b[0m: "
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 19.6 s, sys: 14 s, total: 33.6 s\n",
+      "Wall time: 3min 5s\n"
      ]
     }
    ],

--- a/geoparquet/geoparquet-example.ipynb
+++ b/geoparquet/geoparquet-example.ipynb
@@ -1,0 +1,237 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# GeoParquet Example\n",
+    "\n",
+    "This notebook will give an overview of how to read and write GeoParquet files with GeoPandas, putting an emphasis on cloud-native operations where possible.\n",
+    "\n",
+    "The easiest way to read and write GeoParquet files is to use GeoPandas' [`read_parquet`](https://geopandas.org/en/stable/docs/reference/api/geopandas.read_parquet.html) and [`to_geoparquet`](https://geopandas.org/en/stable/docs/reference/api/geopandas.GeoDataFrame.to_parquet.html) functions.\n",
+    "\n",
+    "::: {.callout-note}\n",
+    "\n",
+    "Make sure to use the specific `read_parquet` and `to_parquet` functions. These will be much, much faster than using the usual `read_file` and `to_file`.\n",
+    "\n",
+    ":::"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import geopandas as gpd\n",
+    "from fsspec.implementations.http import HTTPFileSystem\n",
+    "from urllib.request import urlretrieve\n",
+    "import fsspec"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Reading from local disk\n",
+    "\n",
+    "First we'll cover reading and writing GeoParquet files on local disk storage.\n",
+    "\n",
+    "To be consistent with the FlatGeobuf example, we'll fetch the same US counties FlatGeobuf file (13 MB) and convert it to GeoParquet using `ogr2ogr`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# URL to download\n",
+    "url = \"https://flatgeobuf.org/test/data/UScounties.fgb\"\n",
+    "\n",
+    "# Download, saving to the current directory\n",
+    "local_fgb_path, _ = urlretrieve(url, \"countries.fgb\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!ogr2ogr countries.parquet countries.fgb"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Loading this GeoParquet file is really fast! 13% faster than loading the same data via FlatGeobuf (shown in the FlatGeobuf example notebook)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "21.2 ms ± 266 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "%timeit gdf = gpd.read_parquet(\"countries.parquet\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Writing to local disk\n",
+    "\n",
+    "We can use `GeoDataFrame.to_parquet` to write out this data to GeoParquet files locally. This is about 3x faster than writing the same dataset to FlatGeobuf, but note that FlatGeobuf's writing is also calculating a spatial index."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "35.9 ms ± 723 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "%timeit gdf.to_parquet(\"countries_written.parquet\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Reading from the cloud\n",
+    "\n",
+    "As of GeoParquet version 1.0.0-rc.1, spatial indexing has not yet been implemented. Therefore, there is not yet an API in GeoPandas to read data given a specific bounding box.\n",
+    "\n",
+    "What is already efficient in GeoParquet is reading only specified columns from a dataset."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "url = \"https://data.source.coop/cholmes/eurocrops/unprojected/geoparquet/FR_2018_EC21.parquet\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that since we're fetching this data directly from the cloud, we need to pass in an `fsspec` filesystem object. Otherwise GeoPandas will attempt to load a local file."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "filesystem = HTTPFileSystem()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "By default, calling `read_parquet` will fetch the entire file and parse it all into a single `GeoDataFrame`. Since this is a 3GB file, downloading the file takes a long time:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 27.2 s, sys: 21.3 s, total: 48.5 s\n",
+      "Wall time: 5min 56s\n"
+     ]
+    }
+   ],
+   "source": [
+    "%time gdf = gpd.read_parquet(url, filesystem=filesystem)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can make this faster by only fetching specific columns. Because GeoParquet stores data in a columnar fashion, when selecting only specific columns we can download a lot less data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "KeyboardInterrupt",
+     "evalue": "",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mKeyboardInterrupt\u001b[0m                         Traceback (most recent call last)",
+      "File \u001b[0;32m<timed exec>:1\u001b[0m\n",
+      "File \u001b[0;32m~/.pyenv/versions/3.11.4/lib/python3.11/site-packages/geopandas/io/arrow.py:598\u001b[0m, in \u001b[0;36m_read_parquet\u001b[0;34m(path, columns, storage_options, **kwargs)\u001b[0m\n\u001b[1;32m    596\u001b[0m path \u001b[39m=\u001b[39m _expand_user(path)\n\u001b[1;32m    597\u001b[0m kwargs[\u001b[39m\"\u001b[39m\u001b[39muse_pandas_metadata\u001b[39m\u001b[39m\"\u001b[39m] \u001b[39m=\u001b[39m \u001b[39mTrue\u001b[39;00m\n\u001b[0;32m--> 598\u001b[0m table \u001b[39m=\u001b[39m parquet\u001b[39m.\u001b[39;49mread_table(path, columns\u001b[39m=\u001b[39;49mcolumns, filesystem\u001b[39m=\u001b[39;49mfilesystem, \u001b[39m*\u001b[39;49m\u001b[39m*\u001b[39;49mkwargs)\n\u001b[1;32m    600\u001b[0m \u001b[39m# read metadata separately to get the raw Parquet FileMetaData metadata\u001b[39;00m\n\u001b[1;32m    601\u001b[0m \u001b[39m# (pyarrow doesn't properly exposes those in schema.metadata for files\u001b[39;00m\n\u001b[1;32m    602\u001b[0m \u001b[39m# created by GDAL - https://issues.apache.org/jira/browse/ARROW-16688)\u001b[39;00m\n\u001b[1;32m    603\u001b[0m metadata \u001b[39m=\u001b[39m \u001b[39mNone\u001b[39;00m\n",
+      "File \u001b[0;32m~/.pyenv/versions/3.11.4/lib/python3.11/site-packages/pyarrow/parquet/core.py:2986\u001b[0m, in \u001b[0;36mread_table\u001b[0;34m(source, columns, use_threads, metadata, schema, use_pandas_metadata, read_dictionary, memory_map, buffer_size, partitioning, filesystem, filters, use_legacy_dataset, ignore_prefixes, pre_buffer, coerce_int96_timestamp_unit, decryption_properties, thrift_string_size_limit, thrift_container_size_limit)\u001b[0m\n\u001b[1;32m   2975\u001b[0m         \u001b[39m# TODO test that source is not a directory or a list\u001b[39;00m\n\u001b[1;32m   2976\u001b[0m         dataset \u001b[39m=\u001b[39m ParquetFile(\n\u001b[1;32m   2977\u001b[0m             source, metadata\u001b[39m=\u001b[39mmetadata, read_dictionary\u001b[39m=\u001b[39mread_dictionary,\n\u001b[1;32m   2978\u001b[0m             memory_map\u001b[39m=\u001b[39mmemory_map, buffer_size\u001b[39m=\u001b[39mbuffer_size,\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m   2983\u001b[0m             thrift_container_size_limit\u001b[39m=\u001b[39mthrift_container_size_limit,\n\u001b[1;32m   2984\u001b[0m         )\n\u001b[0;32m-> 2986\u001b[0m     \u001b[39mreturn\u001b[39;00m dataset\u001b[39m.\u001b[39;49mread(columns\u001b[39m=\u001b[39;49mcolumns, use_threads\u001b[39m=\u001b[39;49muse_threads,\n\u001b[1;32m   2987\u001b[0m                         use_pandas_metadata\u001b[39m=\u001b[39;49muse_pandas_metadata)\n\u001b[1;32m   2989\u001b[0m warnings\u001b[39m.\u001b[39mwarn(\n\u001b[1;32m   2990\u001b[0m     \u001b[39m\"\u001b[39m\u001b[39mPassing \u001b[39m\u001b[39m'\u001b[39m\u001b[39muse_legacy_dataset=True\u001b[39m\u001b[39m'\u001b[39m\u001b[39m to get the legacy behaviour is \u001b[39m\u001b[39m\"\u001b[39m\n\u001b[1;32m   2991\u001b[0m     \u001b[39m\"\u001b[39m\u001b[39mdeprecated as of pyarrow 8.0.0, and the legacy implementation will \u001b[39m\u001b[39m\"\u001b[39m\n\u001b[1;32m   2992\u001b[0m     \u001b[39m\"\u001b[39m\u001b[39mbe removed in a future version.\u001b[39m\u001b[39m\"\u001b[39m,\n\u001b[1;32m   2993\u001b[0m     \u001b[39mFutureWarning\u001b[39;00m, stacklevel\u001b[39m=\u001b[39m\u001b[39m2\u001b[39m)\n\u001b[1;32m   2995\u001b[0m \u001b[39mif\u001b[39;00m ignore_prefixes \u001b[39mis\u001b[39;00m \u001b[39mnot\u001b[39;00m \u001b[39mNone\u001b[39;00m:\n",
+      "File \u001b[0;32m~/.pyenv/versions/3.11.4/lib/python3.11/site-packages/pyarrow/parquet/core.py:2614\u001b[0m, in \u001b[0;36m_ParquetDatasetV2.read\u001b[0;34m(self, columns, use_threads, use_pandas_metadata)\u001b[0m\n\u001b[1;32m   2606\u001b[0m         index_columns \u001b[39m=\u001b[39m [\n\u001b[1;32m   2607\u001b[0m             col \u001b[39mfor\u001b[39;00m col \u001b[39min\u001b[39;00m _get_pandas_index_columns(metadata)\n\u001b[1;32m   2608\u001b[0m             \u001b[39mif\u001b[39;00m \u001b[39mnot\u001b[39;00m \u001b[39misinstance\u001b[39m(col, \u001b[39mdict\u001b[39m)\n\u001b[1;32m   2609\u001b[0m         ]\n\u001b[1;32m   2610\u001b[0m         columns \u001b[39m=\u001b[39m (\n\u001b[1;32m   2611\u001b[0m             \u001b[39mlist\u001b[39m(columns) \u001b[39m+\u001b[39m \u001b[39mlist\u001b[39m(\u001b[39mset\u001b[39m(index_columns) \u001b[39m-\u001b[39m \u001b[39mset\u001b[39m(columns))\n\u001b[1;32m   2612\u001b[0m         )\n\u001b[0;32m-> 2614\u001b[0m table \u001b[39m=\u001b[39m \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49m_dataset\u001b[39m.\u001b[39;49mto_table(\n\u001b[1;32m   2615\u001b[0m     columns\u001b[39m=\u001b[39;49mcolumns, \u001b[39mfilter\u001b[39;49m\u001b[39m=\u001b[39;49m\u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49m_filter_expression,\n\u001b[1;32m   2616\u001b[0m     use_threads\u001b[39m=\u001b[39;49muse_threads\n\u001b[1;32m   2617\u001b[0m )\n\u001b[1;32m   2619\u001b[0m \u001b[39m# if use_pandas_metadata, restore the pandas metadata (which gets\u001b[39;00m\n\u001b[1;32m   2620\u001b[0m \u001b[39m# lost if doing a specific `columns` selection in to_table)\u001b[39;00m\n\u001b[1;32m   2621\u001b[0m \u001b[39mif\u001b[39;00m use_pandas_metadata:\n",
+      "\u001b[0;31mKeyboardInterrupt\u001b[0m: "
+     ]
+    }
+   ],
+   "source": [
+    "%time gdf = gpd.read_parquet(url, columns=[\"ID_PARCEL\", \"geometry\"], filesystem=filesystem)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.4"
+  },
+  "orig_nbformat": 4
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/geoparquet/geoparquet-example.ipynb
+++ b/geoparquet/geoparquet-example.ipynb
@@ -19,14 +19,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
-    "import geopandas as gpd\n",
-    "from fsspec.implementations.http import HTTPFileSystem\n",
     "from urllib.request import urlretrieve\n",
-    "import fsspec"
+    "\n",
+    "import fsspec\n",
+    "import geopandas as gpd\n",
+    "from fsspec.implementations.http import HTTPFileSystem"
    ]
   },
   {
@@ -123,7 +124,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -139,7 +140,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -197,11 +198,364 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Working with GeoParquet row groups (Advanced)\n",
+    "\n",
+    "As described in the [intro document](./index.qmd), GeoParquet is a chunked format, which allows you to access one of the chunks of rows very efficiently. This can allow you to stream a dataset — loading and operating on one chunk at a time — if the dataset is larger than your memory.\n",
+    "\n",
+    "GeoPandas does not yet have built-in support for working with row groups, so this section will use the underlying [`pyarrow`](https://arrow.apache.org/docs/python/index.html) library directly."
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "import pyarrow.parquet as pq\n",
+    "from geopandas.io.arrow import _arrow_to_geopandas"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "First, we'll create a [`ParquetFile`](https://arrow.apache.org/docs/python/generated/pyarrow.parquet.ParquetFile.html#pyarrow.parquet.ParquetFile) object from the remote URL. All this does is load the metadata from the file, allowing you to inspect the schema and number of columns, rows, and row groups. Because this doesn't load any actual data, it's nearly instant to complete."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "parquet_file = pq.ParquetFile(url, filesystem=filesystem)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can access the column names in the dataset:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['ID_PARCEL',\n",
+       " 'SURF_PARC',\n",
+       " 'CODE_CULTU',\n",
+       " 'CODE_GROUP',\n",
+       " 'CULTURE_D1',\n",
+       " 'CULTURE_D2',\n",
+       " 'EC_org_n',\n",
+       " 'EC_trans_n',\n",
+       " 'EC_hcat_n',\n",
+       " 'EC_hcat_c',\n",
+       " 'geometry']"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "parquet_file.schema_arrow.names"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As well as the number of row groups:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "146"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "parquet_file.num_row_groups"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Then to load one of the row groups by numeric index, we can call [`ParquetFile.read_row_group`](https://arrow.apache.org/docs/python/generated/pyarrow.parquet.ParquetFile.html#pyarrow.parquet.ParquetFile.read_row_group)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pyarrow_table = parquet_file.read_row_group(0)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that this returns a [`pyarrow.Table`](https://arrow.apache.org/docs/python/generated/pyarrow.Table.html#pyarrow.Table), not a `geopandas.GeoDataFrame`. To convert between the two, we can use `_arrow_to_geopandas`. This conversion is very fast."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>ID_PARCEL</th>\n",
+       "      <th>SURF_PARC</th>\n",
+       "      <th>CODE_CULTU</th>\n",
+       "      <th>CODE_GROUP</th>\n",
+       "      <th>CULTURE_D1</th>\n",
+       "      <th>CULTURE_D2</th>\n",
+       "      <th>EC_org_n</th>\n",
+       "      <th>EC_trans_n</th>\n",
+       "      <th>EC_hcat_n</th>\n",
+       "      <th>EC_hcat_c</th>\n",
+       "      <th>geometry</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>123563</td>\n",
+       "      <td>6.38</td>\n",
+       "      <td>CZH</td>\n",
+       "      <td>5</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
+       "      <td>Colza d’hiver</td>\n",
+       "      <td>Winter rapeseed</td>\n",
+       "      <td>winter_rapeseed_rape</td>\n",
+       "      <td>3301060401</td>\n",
+       "      <td>MULTIPOLYGON (((3.33896 49.84122, 3.33948 49.8...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>5527076</td>\n",
+       "      <td>2.30</td>\n",
+       "      <td>PPH</td>\n",
+       "      <td>18</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
+       "      <td>Prairie permanente - herbe prédominante (resso...</td>\n",
+       "      <td>Permanent pasture - predominantly grass (woody...</td>\n",
+       "      <td>pasture_meadow_grassland_grass</td>\n",
+       "      <td>3302000000</td>\n",
+       "      <td>MULTIPOLYGON (((-1.44483 49.61280, -1.44467 49...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>11479241</td>\n",
+       "      <td>6.33</td>\n",
+       "      <td>PPH</td>\n",
+       "      <td>18</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
+       "      <td>Prairie permanente - herbe prédominante (resso...</td>\n",
+       "      <td>Permanent pasture - predominantly grass (woody...</td>\n",
+       "      <td>pasture_meadow_grassland_grass</td>\n",
+       "      <td>3302000000</td>\n",
+       "      <td>MULTIPOLYGON (((2.87821 46.53674, 2.87820 46.5...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>12928442</td>\n",
+       "      <td>5.10</td>\n",
+       "      <td>PPH</td>\n",
+       "      <td>18</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
+       "      <td>Prairie permanente - herbe prédominante (resso...</td>\n",
+       "      <td>Permanent pasture - predominantly grass (woody...</td>\n",
+       "      <td>pasture_meadow_grassland_grass</td>\n",
+       "      <td>3302000000</td>\n",
+       "      <td>MULTIPOLYGON (((-0.19026 48.28723, -0.19025 48...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>318389</td>\n",
+       "      <td>0.92</td>\n",
+       "      <td>PPH</td>\n",
+       "      <td>18</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
+       "      <td>Prairie permanente - herbe prédominante (resso...</td>\n",
+       "      <td>Permanent pasture - predominantly grass (woody...</td>\n",
+       "      <td>pasture_meadow_grassland_grass</td>\n",
+       "      <td>3302000000</td>\n",
+       "      <td>MULTIPOLYGON (((5.72084 44.03576, 5.72081 44.0...</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "  ID_PARCEL  ...                                           geometry\n",
+       "0    123563  ...  MULTIPOLYGON (((3.33896 49.84122, 3.33948 49.8...\n",
+       "1   5527076  ...  MULTIPOLYGON (((-1.44483 49.61280, -1.44467 49...\n",
+       "2  11479241  ...  MULTIPOLYGON (((2.87821 46.53674, 2.87820 46.5...\n",
+       "3  12928442  ...  MULTIPOLYGON (((-0.19026 48.28723, -0.19025 48...\n",
+       "4    318389  ...  MULTIPOLYGON (((5.72084 44.03576, 5.72081 44.0...\n",
+       "\n",
+       "[5 rows x 11 columns]"
+      ]
+     },
+     "execution_count": 27,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "geopandas_gdf = _arrow_to_geopandas(pyarrow_table, parquet_file.metadata.metadata)\n",
+    "geopandas_gdf.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As before, we can speed up the data fetching by requesting only specific columns in the `read_row_group` call.:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pyarrow_table = parquet_file.read_row_group(0, columns=[\"ID_PARCEL\", \"geometry\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Then the resulting `GeoDataFrame` will only have those two columns:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>ID_PARCEL</th>\n",
+       "      <th>geometry</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>123563</td>\n",
+       "      <td>MULTIPOLYGON (((3.33896 49.84122, 3.33948 49.8...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>5527076</td>\n",
+       "      <td>MULTIPOLYGON (((-1.44483 49.61280, -1.44467 49...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>11479241</td>\n",
+       "      <td>MULTIPOLYGON (((2.87821 46.53674, 2.87820 46.5...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>12928442</td>\n",
+       "      <td>MULTIPOLYGON (((-0.19026 48.28723, -0.19025 48...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>318389</td>\n",
+       "      <td>MULTIPOLYGON (((5.72084 44.03576, 5.72081 44.0...</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "  ID_PARCEL                                           geometry\n",
+       "0    123563  MULTIPOLYGON (((3.33896 49.84122, 3.33948 49.8...\n",
+       "1   5527076  MULTIPOLYGON (((-1.44483 49.61280, -1.44467 49...\n",
+       "2  11479241  MULTIPOLYGON (((2.87821 46.53674, 2.87820 46.5...\n",
+       "3  12928442  MULTIPOLYGON (((-0.19026 48.28723, -0.19025 48...\n",
+       "4    318389  MULTIPOLYGON (((5.72084 44.03576, 5.72081 44.0..."
+      ]
+     },
+     "execution_count": 29,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "_arrow_to_geopandas(pyarrow_table, parquet_file.metadata.metadata).head()"
+   ]
   }
  ],
  "metadata": {

--- a/geoparquet/geoparquet-example.ipynb
+++ b/geoparquet/geoparquet-example.ipynb
@@ -227,7 +227,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 30,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -275,7 +275,34 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As well as the number of row groups:"
+    "This Parquet file includes 9.5 million rows:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "9517874"
+      ]
+     },
+     "execution_count": 34,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "parquet_file.metadata.num_rows"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And 146 row groups. Given that each row group is about the same number of rows, each one contains around 65,000 rows."
    ]
   },
   {
@@ -323,7 +350,43 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 35,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "geopandas_gdf = _arrow_to_geopandas(pyarrow_table, parquet_file.metadata.metadata)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As expected, this row group contains right around 65,000 rows"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(65536, 2)"
+      ]
+     },
+     "execution_count": 36,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "geopandas_gdf.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
    "metadata": {},
    "outputs": [
     {
@@ -348,15 +411,6 @@
        "    <tr style=\"text-align: right;\">\n",
        "      <th></th>\n",
        "      <th>ID_PARCEL</th>\n",
-       "      <th>SURF_PARC</th>\n",
-       "      <th>CODE_CULTU</th>\n",
-       "      <th>CODE_GROUP</th>\n",
-       "      <th>CULTURE_D1</th>\n",
-       "      <th>CULTURE_D2</th>\n",
-       "      <th>EC_org_n</th>\n",
-       "      <th>EC_trans_n</th>\n",
-       "      <th>EC_hcat_n</th>\n",
-       "      <th>EC_hcat_c</th>\n",
        "      <th>geometry</th>\n",
        "    </tr>\n",
        "  </thead>\n",
@@ -364,71 +418,26 @@
        "    <tr>\n",
        "      <th>0</th>\n",
        "      <td>123563</td>\n",
-       "      <td>6.38</td>\n",
-       "      <td>CZH</td>\n",
-       "      <td>5</td>\n",
-       "      <td>None</td>\n",
-       "      <td>None</td>\n",
-       "      <td>Colza d’hiver</td>\n",
-       "      <td>Winter rapeseed</td>\n",
-       "      <td>winter_rapeseed_rape</td>\n",
-       "      <td>3301060401</td>\n",
        "      <td>MULTIPOLYGON (((3.33896 49.84122, 3.33948 49.8...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
        "      <td>5527076</td>\n",
-       "      <td>2.30</td>\n",
-       "      <td>PPH</td>\n",
-       "      <td>18</td>\n",
-       "      <td>None</td>\n",
-       "      <td>None</td>\n",
-       "      <td>Prairie permanente - herbe prédominante (resso...</td>\n",
-       "      <td>Permanent pasture - predominantly grass (woody...</td>\n",
-       "      <td>pasture_meadow_grassland_grass</td>\n",
-       "      <td>3302000000</td>\n",
        "      <td>MULTIPOLYGON (((-1.44483 49.61280, -1.44467 49...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
        "      <td>11479241</td>\n",
-       "      <td>6.33</td>\n",
-       "      <td>PPH</td>\n",
-       "      <td>18</td>\n",
-       "      <td>None</td>\n",
-       "      <td>None</td>\n",
-       "      <td>Prairie permanente - herbe prédominante (resso...</td>\n",
-       "      <td>Permanent pasture - predominantly grass (woody...</td>\n",
-       "      <td>pasture_meadow_grassland_grass</td>\n",
-       "      <td>3302000000</td>\n",
        "      <td>MULTIPOLYGON (((2.87821 46.53674, 2.87820 46.5...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
        "      <td>12928442</td>\n",
-       "      <td>5.10</td>\n",
-       "      <td>PPH</td>\n",
-       "      <td>18</td>\n",
-       "      <td>None</td>\n",
-       "      <td>None</td>\n",
-       "      <td>Prairie permanente - herbe prédominante (resso...</td>\n",
-       "      <td>Permanent pasture - predominantly grass (woody...</td>\n",
-       "      <td>pasture_meadow_grassland_grass</td>\n",
-       "      <td>3302000000</td>\n",
        "      <td>MULTIPOLYGON (((-0.19026 48.28723, -0.19025 48...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
        "      <td>318389</td>\n",
-       "      <td>0.92</td>\n",
-       "      <td>PPH</td>\n",
-       "      <td>18</td>\n",
-       "      <td>None</td>\n",
-       "      <td>None</td>\n",
-       "      <td>Prairie permanente - herbe prédominante (resso...</td>\n",
-       "      <td>Permanent pasture - predominantly grass (woody...</td>\n",
-       "      <td>pasture_meadow_grassland_grass</td>\n",
-       "      <td>3302000000</td>\n",
        "      <td>MULTIPOLYGON (((5.72084 44.03576, 5.72081 44.0...</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
@@ -436,23 +445,20 @@
        "</div>"
       ],
       "text/plain": [
-       "  ID_PARCEL  ...                                           geometry\n",
-       "0    123563  ...  MULTIPOLYGON (((3.33896 49.84122, 3.33948 49.8...\n",
-       "1   5527076  ...  MULTIPOLYGON (((-1.44483 49.61280, -1.44467 49...\n",
-       "2  11479241  ...  MULTIPOLYGON (((2.87821 46.53674, 2.87820 46.5...\n",
-       "3  12928442  ...  MULTIPOLYGON (((-0.19026 48.28723, -0.19025 48...\n",
-       "4    318389  ...  MULTIPOLYGON (((5.72084 44.03576, 5.72081 44.0...\n",
-       "\n",
-       "[5 rows x 11 columns]"
+       "  ID_PARCEL                                           geometry\n",
+       "0    123563  MULTIPOLYGON (((3.33896 49.84122, 3.33948 49.8...\n",
+       "1   5527076  MULTIPOLYGON (((-1.44483 49.61280, -1.44467 49...\n",
+       "2  11479241  MULTIPOLYGON (((2.87821 46.53674, 2.87820 46.5...\n",
+       "3  12928442  MULTIPOLYGON (((-0.19026 48.28723, -0.19025 48...\n",
+       "4    318389  MULTIPOLYGON (((5.72084 44.03576, 5.72081 44.0..."
       ]
      },
-     "execution_count": 27,
+     "execution_count": 37,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "geopandas_gdf = _arrow_to_geopandas(pyarrow_table, parquet_file.metadata.metadata)\n",
     "geopandas_gdf.head()"
    ]
   },
@@ -556,6 +562,11 @@
    "source": [
     "_arrow_to_geopandas(pyarrow_table, parquet_file.metadata.metadata).head()"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
This is a rather slim notebook, but largely because GeoParquet doesn't have great APIs via GeoPandas yet. I.e. there's no way to load just one row group of a GeoParquet file without dipping into `pyarrow` and doing manual operations.


Closes https://github.com/developmentseed/cloud-optimized-geospatial-formats-guide/issues/12